### PR TITLE
Remove "--no-scripts" from composers defaults

### DIFF
--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -37,7 +37,7 @@ set :permission_method,     false
 # Execute set permissions
 set :use_set_permissions,   false
 
-set :composer_install_flags, "--no-dev --no-scripts --verbose --prefer-dist --optimize-autoloader --no-progress"
+set :composer_install_flags, "--no-dev --verbose --prefer-dist --optimize-autoloader --no-progress"
 
 set :symfony_console_path, fetch(:app_path) + "/console"
 set :symfony_console_flags, "--no-debug"


### PR DESCRIPTION
I don't know exactly, what where the issues, but in some cases some things relied on the scripts to be executed right after `install`, so `--no-scripts` broke deployment. Imo it doesn't make much sense anyway to postpone the script execution manually, does it?

Note, that the current capifony doesn't have this behaviour neither.
