### PR TITLE
Add php binary before build_bootstrap.php

### DIFF
--- a/lib/capistrano/tasks/symfony.rake
+++ b/lib/capistrano/tasks/symfony.rake
@@ -30,7 +30,7 @@ namespace :deploy do
     on roles :app do
       within release_path do
         # TODO: does this need to be configurable?
-        execute "./vendor/sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php"
+        execute :php, "./vendor/sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php"
       end
     end
   end


### PR DESCRIPTION
build_bootstrap task should execute php binary, not the script itself.

```
DEBUG [bc4bfe9c]        /usr/bin/env: ./vendor/sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php
DEBUG [05f38581]        /usr/bin/env: ./vendor/sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php
cap aborted!
./vendor/sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php stdout: Nothing written
./vendor/sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php stderr: Nothing written
```

```
cd /var/www/foobar/releases/20140309213947 && ( SYMFONY_ENV=prod /usr/bin/env ./vendor/sensio/distribution-bundle/Sensio/Bundle/DistributionB
undle/Resources/bin/build_bootstrap.php )
/usr/bin/env: ./vendor/sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php: Permission denied
```
