### PR TITLE
'symfony assets:dump' not called during deployment

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -1,7 +1,11 @@
 namespace :deploy do
   namespace :assets do
     task :install do
-      invoke "symfony:command", "assets:install", fetch(:assets_install_path)
+      on release_roles :all do
+        within release_path do
+          execute :php, fetch(:symfony_console_path), "assets:install", fetch(:assets_install_path)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Somehow the roles get lost capistrano invokes `symfony:command` from `deploy:assets:install`. Somebody with more Ruby-experience can probably debug this further, but this one at least works.

Fixes #10
