### PR TITLE
Allow ```symfony:command``` to be executed multiple times

### DIFF
--- a/lib/capistrano/tasks/symfony_console.rake
+++ b/lib/capistrano/tasks/symfony_console.rake
@@ -11,6 +11,8 @@ namespace :symfony do
         execute :php, fetch(:symfony_console_path), command, *command_args, fetch(:symfony_console_flags)
       end
     end
+
+    Rake::Task[t.name].reenable
   end
 
   namespace :cache do


### PR DESCRIPTION
In Rake a task can only be executed once. In our case the `symfony:command` need to be executed multiple times. For example, clearing the cache and compile the assets.

Fix #15 and #10.
