### PR TITLE
Ensure user-land configured symfony-env is used in console task

### DIFF
--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -51,5 +51,3 @@ set :assets_install_flags,  '--symlink'
 
 # Assetic dump flags
 set :assetic_dump_flags,  ''
-
-fetch(:default_env).merge!(symfony_env: fetch(:symfony_env))

--- a/lib/capistrano/tasks/set_symfony_env.rake
+++ b/lib/capistrano/tasks/set_symfony_env.rake
@@ -1,0 +1,9 @@
+namespace :deploy do
+  task :set_symfony_env do
+    fetch(:default_env).merge!(symfony_env: fetch(:symfony_env) || 'prod')
+  end
+end
+
+Capistrano::DSL.stages.each do |stage|
+  after stage, 'deploy:set_symfony_env'
+end

--- a/lib/capistrano/tasks/symfony.rake
+++ b/lib/capistrano/tasks/symfony.rake
@@ -1,3 +1,5 @@
+load File.expand_path("../set_symfony_env.rake", __FILE__)
+
 namespace :symfony do
   desc "Execute a provided symfony command"
   task :console, :command, :params, :role do |t, args|


### PR DESCRIPTION
This copies strategy in
https://github.com/capistrano/rails/blob/master/lib/capistrano/tasks/set_rails_env.rake

Fix for issue #8 (github)
