### PR TITLE
Append --env option to all console commands

### DIFF
--- a/lib/capistrano/tasks/set_symfony_env.rake
+++ b/lib/capistrano/tasks/set_symfony_env.rake
@@ -1,6 +1,9 @@
 namespace :deploy do
   task :set_symfony_env do
-    fetch(:default_env).merge!(symfony_env: fetch(:symfony_env) || 'prod')
+    symfony_env = fetch(:symfony_env) || 'prod'
+
+    fetch(:default_env).merge!(symfony_env: symfony_env)
+    set :symfony_console_flags, fetch(:symfony_console_flags) + ' --env=' + symfony_env
   end
 end
 


### PR DESCRIPTION
All Symfony console commands come with a --env option to control the Symfony environment they will run as. Currently, this option needs to be manually added to the :symfony_console_flags variable in order to work properly.

This pull request appends the --env option to all console commands by default. I have added the functionality to the existing set_symfony_env task, since they share the same purpose.

Please let me know if you would like me to update anything or would rather go about this differently. Thanks!
