### PR TITLE
documentation: set permission methods provided by the file-permissions p...

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ set :file_permissions_paths,         [fetch(:log_path), fetch(:cache_path)]
 # Name used by the Web Server (i.e. www-data for Apache)
 set :webserver_user,        "www-data"
 
-# Method used to set permissions (:chmod, :acl, or :chown)
+# Method used to set permissions (:chmod, :acl, or :chgrp)
 set :permission_method,     false
 
 # Execute set permissions


### PR DESCRIPTION
...lugin are acl, chmod and chgrp, not chown

See https://github.com/capistrano/file-permissions/blob/master/lib/capistrano/tasks/file-permissions.rake
