### PR TITLE
Fix order of symfony:set_permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ deploy
 |   |__ git:create_release
 |   |__ deploy:symlink:shared
 |   |__ symfony:create_cache_dir
-|   |__ symfony:set_permissions
 |__ deploy:updated
 |   |__ symfony:cache:warmup
 |   |__ symfony:clear_controllers
+|   |__ symfony:set_permissions
 |__ deploy:publishing
 |   |__ deploy:symlink:release
 |   |__ deploy:restart

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -7,12 +7,12 @@ namespace :deploy do
 
   task :updating do
     invoke "symfony:create_cache_dir"
-    invoke "symfony:set_permissions"
   end
 
   task :updated do
     invoke "symfony:cache:warmup"
     invoke "symfony:clear_controllers"
+    invoke "symfony:set_permissions"
   end
 
 end


### PR DESCRIPTION
I think the current postion of symfony:set_permissions is wrong. If you use different users for deployment (e.g. deploy) and your web server (www-data), the files generated by symfony:cache:warmup are going to be owned by deploy user instead of www-data as it should be, since symfony:cache:warmup is executed by the deployment user after symfony:set_permission.

This pull request solves the problem and updates the readme documentation as well.
