### PR TITLE
Add config.php on default controllers to clear

### DIFF
--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -17,7 +17,7 @@ set :cache_path,            fetch(:app_path) + "/cache"
 set :app_config_path,       fetch(:app_path) + "/config"
 
 # Controllers to clear
-set :controllers_to_clear, ["app_*.php"]
+set :controllers_to_clear, ["app_*.php", "config.php"]
 
 # Files that need to remain the same between deploys
 set :linked_files,          []


### PR DESCRIPTION
Symfony standard provide a [config.php](https://github.com/symfony/symfony-standard/blob/2.8/web/config.php) file to check env and configure dev application.

This file should not be on production.

I propose to add it on default controllers to clear.