### PR TITLE
Added support for sensio/distribution-bundle@~5.0.0

### DIFF
--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -51,3 +51,6 @@ set :assets_install_flags,  '--symlink'
 
 # Assetic dump flags
 set :assetic_dump_flags,  ''
+
+# SensioDistribution is version 5 or higher
+set :sensio_distribution_version_5,    false

--- a/lib/capistrano/symfony/dsl/paths.rb
+++ b/lib/capistrano/symfony/dsl/paths.rb
@@ -24,6 +24,15 @@ module Capistrano
           release_path.join(fetch(:app_config_path))
       end
 
+      def sensio_distribution_bootstrap_path
+          bootstrap_path = release_path.join('vendor/sensio/distribution-bundle/')
+
+          unless fetch(:sensio_distribution_version_5)
+            bootstrap_path += 'Sensio/Bundle/DistributionBundle/'
+          end
+
+          bootstrap_path += 'Resources/bin/build_bootstrap.php'
+      end
     end
   end
 end

--- a/lib/capistrano/tasks/symfony.rake
+++ b/lib/capistrano/tasks/symfony.rake
@@ -87,7 +87,7 @@ namespace :symfony do
   task :build_bootstrap do
     on release_roles :all do
       within release_path do
-        execute :php, "./vendor/sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php", fetch(:app_path)
+        execute :php, sensio_distribution_bootstrap_path, fetch(:app_path)
       end
     end
   end


### PR DESCRIPTION
It fixes `symfony:build_bootstrap` command for sensio distribution bundle 5 of higher.

I thought about to do `if test("[ -d ... ]")` but it increases a number of commands to remote machines, as for me it's not good.
