### PR TITLE
1.0.0.rc1 - Symfony 3 directory structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Capistrano Symfony 1.x Changelog
+
+
+## `1.0.0.rc1`
+
+https://github.com/capistrano/symfony/compare/0.4.0...1.0.0.rc1
+
+* Use file permissions gem v1
+* Symfony 3 directory structure is on by default
+* Remove `use_set_permission` variable
+* Remove `web/uploads` as a default linked directory
+* Remove support for Assetic (see: https://github.com/symfony/symfony-standard/pull/860)
+* Support SensioLabsDistributionBundle 5 (#49)
+* Support Symfony 3 directory structure (#31)
+* `build_bootstrap_path` is now a DSL method
+* `symfony_console` is now a DSL method (use instead of `invoke "symfony:console"`)
+* Paths DSL file has been moved to `lib/capistrano/dsl/symfony.rb`
+* Deprecated `symfony:command` task has been removed
+* `webserver_user` variable has been removed (#40)
+* Various typo fixes
+
+### Contributors
+
+Thanks to everyone who has filed an issue or submitted a fix
+
+  * @kriswallsmith
+  * @zaerl
+  * @sandermarechal
+  * @pborreli
+  * @wideawake
+  * @issei-m
+  * @alafon

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Capistrano::Symfony
 
-Symfony 2 (standard edition) specific tasks for Capistrano v3
-(inspired by [capifony][2])
+Symfony 2 (standard edition) specific tasks for Capistrano v3 (inspired by [capifony][2]).
 
 It leverages the following capistrano tasks to deploy a Symfony app
 
@@ -12,8 +11,8 @@ It leverages the following capistrano tasks to deploy a Symfony app
 
 ```
 # Gemfile
-gem 'capistrano',  '~> 3.1'
-gem 'capistrano-symfony', '~> 0.1', :github => 'capistrano/symfony'
+gem 'capistrano',  '~> 3.4'
+gem 'capistrano-symfony', '~> 1.0.0.rc1'
 ```
 
 ## Usage
@@ -25,79 +24,74 @@ Require capistrano-symfony in your cap file
 require 'capistrano/symfony'
 ```
 
+
 ### Settings
 
-capistrano-symfony exposes the following settings (displayed with defaults):
+If you are using an un-modified symfony-standard edition, version 3 then you do not need to change/add anything to your `deploy.rb` other than what is required from Capistrano.
+
+We do however expose the following settings (shown with default evaluated values) that can be modified to suit your project. Please refer to `lib/capistrano/symfony/defaults.rb` to see exactly how the defaults are set up.
+
 
 ```ruby
-# Symfony environment
+# Symfony console commands will use this environment for execution
 set :symfony_env,  "prod"
 
-# Symfony application path
-set :app_path,              "app"
+# Set this to 2 for the old directory structure
+set :symfony_directory_structure, 3
+# Set this to 4 if using the older SensioDistributionBundle
+set :sensio_distribution_version, 5
 
-# Symfony web path
-set :web_path,              "web"
+# symfony-standard edition directories
+set :app_path, "app"
+set :web_path, "web"
+set :var_path, "var"
+set :bin_path, "bin"
 
-# Symfony log path
-set :log_path,              fetch(:app_path) + "/logs"
+# The next 3 settings are lazily evaluated from the above values, so take care
+# when modifying them
+set :app_config_path, "app/config"
+set :log_path, "var/logs"
+set :cache_path, "var/cache"
 
-# Symfony cache path
-set :cache_path,            fetch(:app_path) + "/cache"
-
-# Symfony config file path
-set :app_config_path,       fetch(:app_path) + "/config"
-
-# Controllers to clear
-set :controllers_to_clear, ["app_*.php"]
-
-# Files that need to remain the same between deploys
-set :linked_files,          []
-
-# Dirs that need to remain the same between deploys (shared dirs)
-set :linked_dirs,           [fetch(:log_path), fetch(:web_path) + "/uploads"]
-
-# Dirs that need to be writable by the HTTP Server (i.e. cache, log dirs)
-set :file_permissions_paths,         [fetch(:log_path), fetch(:cache_path)]
-
-# Name used by the Web Server (i.e. www-data for Apache)
-set :file_permissions_users, ['www-data']
-
-# Name used by the Web Server (i.e. www-data for Apache)
-set :webserver_user,        "www-data"
-
-# Method used to set permissions (:chmod, :acl, or :chgrp)
-set :permission_method,     false
-
-# Execute set permissions
-set :use_set_permissions,   false
-
-# Symfony console path
-set :symfony_console_path, fetch(:app_path) + "/console"
-
-# Symfony console flags
+set :symfony_console_path, "bin/console"
 set :symfony_console_flags, "--no-debug"
 
-# Assets install path
-set :assets_install_path,   fetch(:web_path)
+# Remove app_dev.php during deployment, other files in web/ can be specified here
+set :controllers_to_clear, ["app_*.php"]
 
-# Assets install flags
+# asset management
+set :assets_install_path, "web"
 set :assets_install_flags,  '--symlink'
 
-# Assetic dump flags
-set :assetic_dump_flags,  ''
+# Share files/directories between releases
+set :linked_files, []
+set :linked_dirs, ["var/logs"]
 
-fetch(:default_env).merge!(symfony_env: fetch(:symfony_env))
+# Set correct permissions between releases, this is turned off by default
+set :file_permissions_paths, ["var"]
+set :permission_method, false
 ```
+
+#### Using this plugin with the old Symfony 2 directory structure and SensioDistributionBundle <= 4
+
+Add the following to `deploy.rb` to use the old directory structure
+
+```
+# deploy.rb
+set :symfony_directory_structure, 2
+set :sensio_distribution_version, 4
+```
+
+If you are upgrading this gem and have modified `linked_dirs` or "advanced" variables such as `log_path` then you will need to update those accordingly
 
 ### Flow
 
 capistrano-symfony hooks into the [flow][1] offered by capistrano. It adds to that flow like so
 
-* ```symfony:create_cache_dir```
-* ```symfony:set_permissions```
-* ```symfony:cache:warmup```
-* ```symfony:clear_controllers```
+* `symfony:create_cache_dir`
+* `symfony:set_permissions`
+* `symfony:cache:warmup`
+* `symfony:clear_controllers`
 
 ```
 deploy
@@ -125,16 +119,38 @@ deploy
     |__ deploy:log_revision
 ```
 
+### File permissions
+
+Set the `permission_method` variable to one of `:chmod`, `:acl`, or `:chgrp` in your `deploy.rb` to handle the common scenario of a web user and the deploy user being different.
+
+Both will need access to the files/directories such as `var/cache` and `web/uploads` (if you handle uploads). Set `file_permissions_users` to your webserver user
+
+Example:
+
+```
+# deploy.rb
+
+set :permission_method, :acl
+set :file_permissions_users, ["nginx"]
+set :file_permissions_paths, ["var", "web/uploads"]
+```
+
+Please note that `:acl` requires that `setfacl` be available on your deployment target
+
+See [the symfony documentation](http://symfony.com/doc/current/book/installation.html#checking-symfony-application-configuration-and-setup) and [the file permission capistrano plugin](https://github.com/capistrano/file-permissions) for reference
+
 ### Integrated common tasks
 
-The folowing common tasks are already integrated:
-* ```symfony:assets:install```
-* ```symfony:assetic:dump```
+The following common tasks are available:
 
-So you can use them with hooks like this:
+* `symfony:assets:install`
+* `symfony:build_bootstrap` - useful if you disable composer
+
+So you can use them with hooks in your project's `deploy.rb` like this:
+
 ```ruby
-  after 'deploy:updated',   'symfony:assets:install'
-  after 'deploy:updated',   'symfony:assetic:dump'
+after 'deploy:updated', 'symfony:assets:install'
+before 'deploy:updated', 'symfony:build_bootstrap'
 ```
 
 ### Using the Symfony console
@@ -148,17 +164,19 @@ project you may want to run migrations during a deploy.
 ```ruby
 namespace :deploy do
   task :migrate do
-    invoke 'symfony:console', 'doctrine:migrations:migrate', '--no-interaction'
+    symfony_console('doctrine:migrations:migrate', '--no-interaction')
   end
 end
 ```
 
-You can also apply role filter on your commands by passing a fourth parameter.
+If you want to execute a command on a host with a given role you can use the Capistrano `on` DSL, additionally using `within` from Capistrano will change the directory
 
 ```ruby
 namespace :deploy do
   task :migrate do
-    invoke 'symfony:console', 'doctrine:migrations:migrate', '--no-interaction', 'db'
+    on roles(:db) do
+      symfony_console('doctrine:migrations:migrate', '--no-interaction')
+    end
   end
 end
 ```

--- a/capistrano-symfony.gemspec
+++ b/capistrano-symfony.gemspec
@@ -4,11 +4,11 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "capistrano-symfony"
-  gem.version       = '0.4.0'
+  gem.version       = '1.0.0.rc1'
   gem.authors       = ["Peter Mitchell"]
   gem.email         = ["pete@peterjmit.com"]
   gem.description   = %q{Symfony specific Capistrano tasks}
-  gem.summary       = %q{Capistrano Symfony - Easy deployment of Symfony 2 apps with Ruby over SSH}
+  gem.summary       = %q{Capistrano Symfony - Easy deployment of Symfony 2 & 3 apps with Ruby over SSH}
   gem.homepage      = "http://github.com/capistrano/capistrano-symfony"
 
   gem.files         = `git ls-files`.split($/)
@@ -31,5 +31,5 @@ eos
 
   gem.add_dependency 'capistrano', '~> 3.1'
   gem.add_dependency 'capistrano-composer', '~> 0.0.3'
-  gem.add_dependency 'capistrano-file-permissions', '~> 0.1.0'
+  gem.add_dependency 'capistrano-file-permissions', '~> 1.0'
 end

--- a/lib/capistrano/dsl/symfony.rb
+++ b/lib/capistrano/dsl/symfony.rb
@@ -10,6 +10,14 @@ module Capistrano
           release_path.join(fetch(:web_path))
       end
 
+      def symfony_bin_path
+        release_path.join(fetch(:bin_path))
+      end
+
+      def symfony_var_path
+        release_path.join(fetch(:var_path))
+      end
+
       def symfony_log_path
           release_path.join(fetch(:log_path))
       end

--- a/lib/capistrano/dsl/symfony.rb
+++ b/lib/capistrano/dsl/symfony.rb
@@ -1,8 +1,6 @@
-require "capistrano/dsl/paths"
-
 module Capistrano
   module DSL
-    module Paths
+    module Symfony
 
       def symfony_app_path
           release_path.join(fetch(:app_path))

--- a/lib/capistrano/dsl/symfony.rb
+++ b/lib/capistrano/dsl/symfony.rb
@@ -39,7 +39,13 @@ module Capistrano
       end
 
       def build_bootstrap_path
-        symfony_vendor_path.join("sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php")
+        bootstrap_path = symfony_vendor_path.join("sensio/distribution-bundle")
+
+        if fetch(:sensio_distribution_version).to_i <= 4
+          bootstrap_path = bootstrap_path.join("Sensio/Bundle/DistributionBundle")
+        end
+
+        bootstrap_path.join("Resources/bin/build_bootstrap.php")
       end
 
       def symfony_console(command, params = '')

--- a/lib/capistrano/dsl/symfony.rb
+++ b/lib/capistrano/dsl/symfony.rb
@@ -26,6 +26,14 @@ module Capistrano
           release_path.join(fetch(:symfony_console_path))
       end
 
+      def symfony_vendor_path
+        release_path.join('vendor')
+      end
+
+      def build_bootstrap_path
+        symfony_vendor_path.join("sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php")
+      end
+
       def symfony_console(command, params = '')
         execute :php, symfony_console_path, command, params, fetch(:symfony_console_flags)
       end

--- a/lib/capistrano/dsl/symfony.rb
+++ b/lib/capistrano/dsl/symfony.rb
@@ -22,6 +22,14 @@ module Capistrano
           release_path.join(fetch(:app_config_path))
       end
 
+      def symfony_console_path
+          release_path.join(fetch(:symfony_console_path))
+      end
+
+      def symfony_console(command, params = '')
+        execute :php, symfony_console_path, command, params, fetch(:symfony_console_flags)
+      end
+
     end
   end
 end

--- a/lib/capistrano/symfony.rb
+++ b/lib/capistrano/symfony.rb
@@ -1,6 +1,10 @@
+require "capistrano/dsl/symfony"
+self.extend Capistrano::DSL::Symfony
+
+SSHKit::Backend::Netssh.send(:include, Capistrano::DSL::Symfony)
+
 require "capistrano/file-permissions"
 require "capistrano/composer"
-require "capistrano/symfony/dsl"
 require "capistrano/symfony/symfony"
 
 # Core tasks for deploying symfony

--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -1,53 +1,43 @@
-# Symfony environment
+#
+# Symfony defaults
+#
 set :symfony_env,  "prod"
 
-# Symfony application path
-set :app_path,              "app"
+set :symfony_directory_structure, 2
 
-# Symfony web path
-set :web_path,              "web"
+# symfony-standard edition top-level directories
+set :app_path, "app"
+set :web_path, "web"
+set :var_path, "var"
+set :bin_path, "bin"
 
-# Symfony log path
-set :log_path,              fetch(:app_path) + "/logs"
+# Use closures for directories nested under the top level dirs, so that
+# any changes to web/app etc do not require these to be changed also
+set :app_config_path, -> { fetch(:app_path) + "/config" }
+set :log_path, -> { fetch(:symfony_directory_structure) == 2 ? fetch(:app_path) + "/logs" : fetch(:var_path) + "/logs" }
+set :cache_path, -> { fetch(:symfony_directory_structure) == 2 ? fetch(:app_path) + "/cache" : fetch(:var_path) + "/cache" }
 
-# Symfony cache path
-set :cache_path,            fetch(:app_path) + "/cache"
-
-# Symfony config file path
-set :app_config_path,       fetch(:app_path) + "/config"
-
-# Controllers to clear
-set :controllers_to_clear, ["app_*.php"]
-
-# Files that need to remain the same between deploys
-set :linked_files,          []
-
-# Dirs that need to remain the same between deploys (shared dirs)
-set :linked_dirs,           [fetch(:log_path), fetch(:web_path) + "/uploads"]
-
-# Dirs that need to be writable by the HTTP Server (i.e. cache, log dirs)
-set :file_permissions_paths,         [fetch(:log_path), fetch(:cache_path)]
-
-# capistrano/file-permissions default
-set :file_permissions_paths, [fetch(:log_path), fetch(:cache_path)]
-
-# Method used to set permissions (:chmod, :acl, or :chown)
-set :permission_method,     false
-
-# Execute set permissions
-set :use_set_permissions,   false
-
-# Symfony console path
-set :symfony_console_path, fetch(:app_path) + "/console"
-
-# Symfony console flags
+# console
+set :symfony_console_path, -> { fetch(:symfony_directory_structure) == 2 ?  fetch(:app_path) + '/console' : fetch(:bin_path) + "/console" }
 set :symfony_console_flags, "--no-debug"
 
-# Assets install path
-set :assets_install_path,   fetch(:web_path)
+set :controllers_to_clear, ["app_*.php"]
 
-# Assets install flags
+# assets
+set :assets_install_path, fetch(:web_path)
 set :assets_install_flags,  '--symlink'
-
-# Assetic dump flags
 set :assetic_dump_flags,  ''
+
+#
+# Capistrano defaults
+#
+set :linked_files, []
+set :linked_dirs, -> { [fetch(:log_path), fetch(:web_path) + "/uploads"] }
+
+#
+# Configure capistrano/file-permissions defaults
+#
+set :file_permissions_paths, -> { fetch(:symfony_directory_structure) == 2 ? [fetch(:log_path), fetch(:cache_path)] : [fetch(:var_path)] }
+# Method used to set permissions (:chmod, :acl, or :chown)
+set :permission_method, false
+set :use_set_permissions, false

--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -32,7 +32,7 @@ set :assets_install_flags,  '--symlink'
 # Capistrano defaults
 #
 set :linked_files, []
-set :linked_dirs, -> { [fetch(:log_path), fetch(:web_path) + "/uploads"] }
+set :linked_dirs, -> { [fetch(:log_path)] }
 
 #
 # Configure capistrano/file-permissions defaults

--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -40,4 +40,3 @@ set :linked_dirs, -> { [fetch(:log_path)] }
 set :file_permissions_paths, -> { fetch(:symfony_directory_structure) == 2 ? [fetch(:log_path), fetch(:cache_path)] : [fetch(:var_path)] }
 # Method used to set permissions (:chmod, :acl, or :chown)
 set :permission_method, false
-set :use_set_permissions, false

--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -28,8 +28,8 @@ set :linked_dirs,           [fetch(:log_path), fetch(:web_path) + "/uploads"]
 # Dirs that need to be writable by the HTTP Server (i.e. cache, log dirs)
 set :file_permissions_paths,         [fetch(:log_path), fetch(:cache_path)]
 
-# Name used by the Web Server (i.e. www-data for Apache)
-set :webserver_user,        "www-data"
+# capistrano/file-permissions default
+set :file_permissions_paths, [fetch(:log_path), fetch(:cache_path)]
 
 # Method used to set permissions (:chmod, :acl, or :chown)
 set :permission_method,     false

--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -27,7 +27,6 @@ set :controllers_to_clear, ["app_*.php"]
 # assets
 set :assets_install_path, fetch(:web_path)
 set :assets_install_flags,  '--symlink'
-set :assetic_dump_flags,  ''
 
 #
 # Capistrano defaults

--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -4,6 +4,7 @@
 set :symfony_env,  "prod"
 
 set :symfony_directory_structure, 2
+set :sensio_distribution_version, 4
 
 # symfony-standard edition top-level directories
 set :app_path, "app"

--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -3,8 +3,8 @@
 #
 set :symfony_env,  "prod"
 
-set :symfony_directory_structure, 2
-set :sensio_distribution_version, 4
+set :symfony_directory_structure, 3
+set :sensio_distribution_version, 5
 
 # symfony-standard edition top-level directories
 set :app_path, "app"

--- a/lib/capistrano/symfony/dsl.rb
+++ b/lib/capistrano/symfony/dsl.rb
@@ -1,1 +1,0 @@
-require 'capistrano/symfony/dsl/paths'

--- a/lib/capistrano/tasks/symfony.rake
+++ b/lib/capistrano/tasks/symfony.rake
@@ -89,7 +89,7 @@ namespace :symfony do
   task :build_bootstrap do
     on release_roles :all do
       within release_path do
-        execute :php, "./vendor/sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php", fetch(:app_path)
+        execute :php, build_bootstrap_path, fetch(:app_path)
       end
     end
   end

--- a/lib/capistrano/tasks/symfony.rake
+++ b/lib/capistrano/tasks/symfony.rake
@@ -11,7 +11,7 @@ namespace :symfony do
 
     on release_roles(role) do
       within release_path do
-        execute :php, fetch(:symfony_console_path), command, params, fetch(:symfony_console_flags)
+        symfony_console(command, params)
       end
     end
 
@@ -21,26 +21,36 @@ namespace :symfony do
   namespace :cache do
     desc "Run app/console cache:clear for the #{fetch(:symfony_env)} environment"
     task :clear do
-      invoke "symfony:console", "cache:clear"
+      on release_roles(:all) do
+        symfony_console "cache:clear"
+      end
     end
 
     desc "Run app/console cache:warmup for the #{fetch(:symfony_env)} environment"
     task :warmup do
-      invoke "symfony:console", "cache:warmup"
+      on release_roles(:all) do
+        symfony_console "cache:warmup"
+      end
     end
   end
 
   namespace :assets do
     desc "Install assets"
     task :install do
-      invoke "symfony:console", "assets:install", fetch(:assets_install_path) + ' ' + fetch(:assets_install_flags)
+      on release_roles(:all) do
+        within release_path do
+          symfony_console "assets:install", fetch(:assets_install_path) + ' ' + fetch(:assets_install_flags)
+        end
+      end
     end
   end
 
   namespace :assetic do
     desc "Dump assets with Assetic"
     task :dump do
-      invoke "symfony:console", "assetic:dump", fetch(:assetic_dump_flags)
+      on release_roles(:all) do
+        symfony_console "assetic:dump", fetch(:assetic_dump_flags)
+      end
     end
   end
 

--- a/lib/capistrano/tasks/symfony.rake
+++ b/lib/capistrano/tasks/symfony.rake
@@ -45,15 +45,6 @@ namespace :symfony do
     end
   end
 
-  namespace :assetic do
-    desc "Dump assets with Assetic"
-    task :dump do
-      on release_roles(:all) do
-        symfony_console "assetic:dump", fetch(:assetic_dump_flags)
-      end
-    end
-  end
-
   desc "Create the cache directory"
   task :create_cache_dir do
     on release_roles :all do

--- a/lib/capistrano/tasks/symfony.rake
+++ b/lib/capistrano/tasks/symfony.rake
@@ -18,14 +18,6 @@ namespace :symfony do
     Rake::Task[t.name].reenable
   end
 
-  task :command, :command_name, :flags do |t, args|
-    on roles(:all) do
-      warn "The task symfony:command is deprecated in favor of symfony:console"
-      invoke "symfony:console", args[:command_name], args[:flags]
-    end
-  end
-
-
   namespace :cache do
     desc "Run app/console cache:clear for the #{fetch(:symfony_env)} environment"
     task :clear do

--- a/lib/capistrano/tasks/symfony.rake
+++ b/lib/capistrano/tasks/symfony.rake
@@ -60,7 +60,7 @@ namespace :symfony do
   desc "Set user/group permissions on configured paths"
   task :set_permissions do
     on release_roles :all do
-      if fetch(:use_set_permissions)
+      if fetch(:permission_method) != false
         invoke "deploy:set_permissions:#{fetch(:permission_method).to_s}"
       end
     end


### PR DESCRIPTION
This PR addresses the following #40, #31, #49, thank you @korotovsky for your contribution and I hope you don't mind rolling them into here.

The gem is available on rubygems for testing (https://rubygems.org/gems/capistrano-symfony/versions/1.0.0.rc1) and I will be looking to tag a v1.0.0 release by the end of the month.

See the [changelog](https://github.com/capistrano/symfony/blob/next/CHANGELOG.md) for details


TODO: 

- [ ] Fix bug in build bootstrap (requires `var_path`, not `app_path`)
