### PR TITLE
upgrade to capistrano-file-permissions 1.0.0

### DIFF
--- a/capistrano-symfony.gemspec
+++ b/capistrano-symfony.gemspec
@@ -31,5 +31,5 @@ eos
 
   gem.add_dependency 'capistrano', '~> 3.1'
   gem.add_dependency 'capistrano-composer', '~> 0.0.3'
-  gem.add_dependency 'capistrano-file-permissions', '~> 0.1.0'
+  gem.add_dependency 'capistrano-file-permissions', '~> 1.0.0'
 end


### PR DESCRIPTION
This version brings recursivity to the setfacl, making sure that every directory has correct permissions, even if it was created before setfacl was run.