### PR TITLE
Add log path to file permission paths for Symfony 3 directory structure

### DIFF
--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -37,6 +37,6 @@ set :linked_dirs, -> { [fetch(:log_path)] }
 #
 # Configure capistrano/file-permissions defaults
 #
-set :file_permissions_paths, -> { fetch(:symfony_directory_structure) == 2 ? [fetch(:log_path), fetch(:cache_path)] : [fetch(:var_path)] }
+set :file_permissions_paths, -> { fetch(:symfony_directory_structure) == 2 ? [fetch(:log_path), fetch(:cache_path)] : [fetch(:var_path), fetch(:log_path)] }
 # Method used to set permissions (:chmod, :acl, or :chown)
 set :permission_method, false


### PR DESCRIPTION
Since the log path by default is a linked dir, it should be explicitly included in the default file permission paths, since these don't recurse through symlinks (at least not for ACL).
