### PR TITLE
[+] isolate symfony deploy from other deploy roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ set :linked_dirs, ["var/logs"]
 # Set correct permissions between releases, this is turned off by default
 set :file_permissions_paths, ["var"]
 set :permission_method, false
+
+# Set roles for deply symfony (set :symfony_deploy_roles, %{app cli})
+set :symfony_deploy_roles, :all
+
 ```
 
 #### Using this plugin with the old Symfony 2 directory structure and SensioDistributionBundle <= 4

--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -40,3 +40,5 @@ set :linked_dirs, -> { [fetch(:log_path)] }
 set :file_permissions_paths, -> { fetch(:symfony_directory_structure) == 2 ? [fetch(:log_path), fetch(:cache_path)] : [fetch(:var_path)] }
 # Method used to set permissions (:chmod, :acl, or :chown)
 set :permission_method, false
+
+set :symfony_deploy_roles, :all

--- a/lib/capistrano/tasks/symfony.rake
+++ b/lib/capistrano/tasks/symfony.rake
@@ -6,7 +6,7 @@ namespace :symfony do
     # ask only runs if argument is not provided
     ask(:cmd, "cache:clear")
     command = args[:command] || fetch(:cmd)
-    role = args[:role] || :all
+    role = args[:role] || fetch(:symfony_deploy_roles)
     params = args[:params] || ''
 
     on release_roles(role) do
@@ -21,14 +21,14 @@ namespace :symfony do
   namespace :cache do
     desc "Run app/console cache:clear for the #{fetch(:symfony_env)} environment"
     task :clear do
-      on release_roles(:all) do
+      on roles(fetch(:symfony_deploy_roles)) do
         symfony_console "cache:clear"
       end
     end
 
     desc "Run app/console cache:warmup for the #{fetch(:symfony_env)} environment"
     task :warmup do
-      on release_roles(:all) do
+      on roles(fetch(:symfony_deploy_roles)) do
         symfony_console "cache:warmup"
       end
     end
@@ -37,7 +37,7 @@ namespace :symfony do
   namespace :assets do
     desc "Install assets"
     task :install do
-      on release_roles(:all) do
+      on roles(fetch(:symfony_deploy_roles)) do
         within release_path do
           symfony_console "assets:install", fetch(:assets_install_path) + ' ' + fetch(:assets_install_flags)
         end
@@ -47,7 +47,7 @@ namespace :symfony do
 
   desc "Create the cache directory"
   task :create_cache_dir do
-    on release_roles :all do
+    on roles(fetch(:symfony_deploy_roles)) do
       within release_path do
         if test "[ -d #{symfony_cache_path} ]"
           execute :rm, "-rf", symfony_cache_path
@@ -59,7 +59,7 @@ namespace :symfony do
 
   desc "Set user/group permissions on configured paths"
   task :set_permissions do
-    on release_roles :all do
+    on roles(fetch(:symfony_deploy_roles)) do
       if fetch(:permission_method) != false
         invoke "deploy:set_permissions:#{fetch(:permission_method).to_s}"
       end
@@ -69,7 +69,7 @@ namespace :symfony do
   desc "Clear non production controllers"
   task :clear_controllers do
     next unless any? :controllers_to_clear
-    on release_roles :all do
+    on roles(fetch(:symfony_deploy_roles)) do
       within symfony_web_path do
         execute :rm, "-f", *fetch(:controllers_to_clear)
       end
@@ -78,7 +78,7 @@ namespace :symfony do
 
   desc "Build the bootstrap file"
   task :build_bootstrap do
-    on release_roles :all do
+    on roles(fetch(:symfony_deploy_roles)) do
       within release_path do
         if fetch(:symfony_directory_structure) == 2
           execute :php, build_bootstrap_path, fetch(:app_path)


### PR DESCRIPTION
current pull request contents new setting variable :symfony_deploy_roles, for isolate deploy symfony from other deploy roles (other servers may not have symfony, php and used only for maintance/static/cdn roles)
