### PR TITLE
Removed unnecessary filter from task symfony:set_permissions

### DIFF
--- a/lib/capistrano/tasks/symfony.rake
+++ b/lib/capistrano/tasks/symfony.rake
@@ -59,10 +59,8 @@ namespace :symfony do
 
   desc "Set user/group permissions on configured paths"
   task :set_permissions do
-    on release_roles :all do
-      if fetch(:permission_method) != false
-        invoke "deploy:set_permissions:#{fetch(:permission_method).to_s}"
-      end
+    if fetch(:permission_method) != false
+      invoke "deploy:set_permissions:#{fetch(:permission_method).to_s}"
     end
   end
 


### PR DESCRIPTION
This was causing DSL method 'invoke' to be called multiple times if multiple hosts were defined, causing an error because Rake tasks should only be invoked once. Refer to issue #78 for information.