### PR TITLE
PHP executable used to run Symfony commands can be configured

### DIFF
--- a/lib/capistrano/dsl/symfony.rb
+++ b/lib/capistrano/dsl/symfony.rb
@@ -40,7 +40,7 @@ module Capistrano
 
       def symfony_console(command, params = '')
         on release_roles(fetch(:symfony_deploy_roles)) do
-          execute :php, symfony_console_path, command, params, fetch(:symfony_console_flags)
+          execute fetch(:php), symfony_console_path, command, params, fetch(:symfony_console_flags)
         end
       end
 

--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -14,6 +14,9 @@ set :web_path, "public"
 set :log_path, -> { fetch(:var_path) + "/log" }
 set :cache_path, -> { fetch(:var_path) + "/cache" }
 
+# PHP executable used to run commands
+set :php, "php"
+
 # console
 set :symfony_console_path, -> { fetch(:bin_path) + "/console" }
 set :symfony_console_flags, "--no-debug"


### PR DESCRIPTION
Hello,

On a new server, we have several PHP executables, and we need to be able to pick which one to use.
I feel like it must be a pretty common use case, I propose to add a configuration option.
Default value is the same, no BC-break.