### PR TITLE
Fixed missing "symfony_deploy_roles" variable in defaults.rb

### DIFF
--- a/lib/capistrano/symfony/defaults.rb
+++ b/lib/capistrano/symfony/defaults.rb
@@ -43,3 +43,4 @@ set :permission_method, false
 
 # Role filtering
 set :symfony_roles, :all
+set :symfony_deploy_roles, :all


### PR DESCRIPTION
Fixed missing `:symfony_deploy_roles` variable in `lib/capistrano/symfony/defaults.rb` that caused tasks like `symfony:clear_controllers` to not being executed.

This fixes #90 and complete changes made in #101.